### PR TITLE
Added "quicktags" check

### DIFF
--- a/codecolorer.php
+++ b/codecolorer.php
@@ -195,6 +195,9 @@ class CodeColorerLoader
         if (!is_admin()) {
             return;
         }
+        
+        if ( ! wp_script_is('quicktags') )
+            return;
 
         wp_enqueue_script('jquery');
         $url = plugins_url(basename(dirname(__FILE__)) . '/js/quicktags.js');

--- a/codecolorer.php
+++ b/codecolorer.php
@@ -196,9 +196,10 @@ class CodeColorerLoader
             return;
         }
         
-        if ( ! wp_script_is('quicktags') )
+        if (!wp_script_is('quicktags')) {
             return;
-
+        }    
+        
         wp_enqueue_script('jquery');
         $url = plugins_url(basename(dirname(__FILE__)) . '/js/quicktags.js');
         wp_enqueue_script('codecolorer', $url, array('jquery'), CODECOLORER_VERSION, true);


### PR DESCRIPTION
Added "quicktags" check in order to avoid js issue on non-editor admin pages.

Without the check, your plugin is blocking other scripts from being executed properly.

<img width="1223" alt="bildschirmfoto 2018-02-24 um 12 01 59" src="https://user-images.githubusercontent.com/2278756/36625883-ce24b9a0-195a-11e8-8d02-6e4bcbe54f90.png">
