### PR TITLE
Addressed a script injection in custom CSS classes and custom CSS block

### DIFF
--- a/codecolorer-admin.php
+++ b/codecolorer-admin.php
@@ -77,7 +77,7 @@ class CodeColorerAdmin
                     <tr valign="top">
                         <th scope="row"><label for="codecolorer_lines_to_scroll"><?php _e('Lines to scroll', 'codecolorer') ?>:</label></th>
                         <td>
-                            <input name="codecolorer_lines_to_scroll" type="number" class="small-text" size="60" id="codecolorer_lines_to_scroll" value="<?php echo get_option('codecolorer_lines_to_scroll') ?>"/>
+                            <input name="codecolorer_lines_to_scroll" type="number" class="small-text" size="60" id="codecolorer_lines_to_scroll" value="<?php echo esc_html(get_option('codecolorer_lines_to_scroll')) ?>"/>
                             <p class="description"><?php _e('If your code lines number is less than this value, block height would not be fixed. Set to <b>-1</b> to remove vertical scroll.', 'codecolorer') ?></p>
                         </td>
                     </tr>
@@ -85,7 +85,7 @@ class CodeColorerAdmin
                     <tr valign="top">
                         <th scope="row"><label for="codecolorer_width"><?php _e('Width', 'codecolorer') ?>:</label></th>
                         <td>
-                            <input name="codecolorer_width" type="string" class="small-text" size="60" id="codecolorer_width" value="<?php echo get_option('codecolorer_width') ?>"/>
+                            <input name="codecolorer_width" type="string" class="small-text" size="60" id="codecolorer_width" value="<?php echo esc_html(get_option('codecolorer_width')) ?>"/>
                             <p class="description"><?php _e('Default code block width. Integer means pixels, also you can specify <tt>em</tt> or <tt>%</tt> suffix. Could be omitted to use whole width.', 'codecolorer') ?></p>
                         </td>
                     </tr>
@@ -93,7 +93,7 @@ class CodeColorerAdmin
                     <tr valign="top">
                         <th scope="row"><label for="codecolorer_height"><?php _e('Height', 'codecolorer') ?>:</label></th>
                         <td>
-                            <input name="codecolorer_height" type="number" class="small-text" size="60" id="codecolorer_height" value="<?php echo get_option('codecolorer_height') ?>"/>
+                            <input name="codecolorer_height" type="number" class="small-text" size="60" id="codecolorer_height" value="<?php echo esc_html(get_option('codecolorer_height')) ?>"/>
                             <p class="description"><?php _e('When code has more than &quot;Lines to Scroll&quot; lines, block height will be set to this value.', 'codecolorer') ?></p>
                         </td>
                     </tr>
@@ -101,7 +101,7 @@ class CodeColorerAdmin
                     <tr valign="top">
                         <th scope="row"><label for="codecolorer_rss_width"><?php _e('Width in RSS', 'codecolorer') ?>:</label></th>
                         <td>
-                            <input name="codecolorer_rss_width" type="number" class="small-text" size="60" id="codecolorer_rss_width" value="<?php echo get_option('codecolorer_rss_width') ?>"/>
+                            <input name="codecolorer_rss_width" type="number" class="small-text" size="60" id="codecolorer_rss_width" value="<?php echo esc_html(get_option('codecolorer_rss_width')) ?>"/>
                             <p class="description"><?php _e('Default code block width in RSS. See Width option description.', 'codecolorer') ?></p>
                         </td>
                     </tr>
@@ -109,7 +109,7 @@ class CodeColorerAdmin
                     <tr valign="top">
                         <th scope="row"><label for="codecolorer_tab_size"><?php _e('Tab size', 'codecolorer') ?>:</label></th>
                         <td>
-                            <input name="codecolorer_tab_size" type="number" class="small-text" size="60" id="codecolorer_tab_size" value="<?php echo get_option('codecolorer_tab_size') ?>"/>
+                            <input name="codecolorer_tab_size" type="number" class="small-text" size="60" id="codecolorer_tab_size" value="<?php echo esc_html(get_option('codecolorer_tab_size')) ?>"/>
                             <p class="description"><?php _e('Indicating how many spaces would represent TAB symbol.', 'codecolorer') ?></p>
                         </td>
                     </tr>
@@ -152,7 +152,7 @@ class CodeColorerAdmin
                     <tr valign="top">
                         <th scope="row"><label for="codecolorer_css_class"><?php _e('Custom CSS Classes', 'codecolorer') ?>:</label></th>
                         <td>
-                            <input name="codecolorer_css_class" type="text" class="regular-text code" size="60" id="codecolorer_css_class" value="<?php echo get_option('codecolorer_css_class') ?>"/>
+                            <input name="codecolorer_css_class" type="text" class="regular-text code" size="60" id="codecolorer_css_class" value="<?php echo esc_html(get_option('codecolorer_css_class')) ?>"/>
                             <p class="description"><?php _e('These custom CSS classes will be appended to the wrapper HTML element.', 'codecolorer') ?></p>
                         </td>
                     </tr>
@@ -160,7 +160,7 @@ class CodeColorerAdmin
                     <tr valign="top">
                         <th scope="row"><label for="codecolorer_css_style"><?php _e('Custom CSS Styles', 'codecolorer') ?>:</label></th>
                         <td>
-                            <textarea name="codecolorer_css_style" id="codecolorer_css_style" class="large-text code" rows="10" cols="60"><?php echo htmlspecialchars(get_option('codecolorer_css_style')) ?></textarea><br />
+                            <textarea name="codecolorer_css_style" id="codecolorer_css_style" class="large-text code" rows="10" cols="60"><?php echo esc_html(get_option('codecolorer_css_style')) ?></textarea><br />
                             <p class="description"><?php _e('These custom CSS rules will be appended to the CodeColorer default CSS file.', 'codecolorer') ?></p>
                         </td>
                     </tr>

--- a/codecolorer-options.php
+++ b/codecolorer-options.php
@@ -278,7 +278,7 @@ class CodeColorerOptions
      */
     protected static function wpOption($name)
     {
-        return get_option($name);
+        return wp_strip_all_tags(get_option($name));
     }
 
     public static function feedOverallStyle()

--- a/codecolorer.php
+++ b/codecolorer.php
@@ -163,7 +163,7 @@ class CodeColorerLoader
         $cssUrl = plugins_url(basename(dirname(__FILE__)) . '/codecolorer.css');
         wp_register_style('codecolorer', $cssUrl, array(), CODECOLORER_VERSION, 'screen');
         wp_enqueue_style('codecolorer');
-        $styles = trim(get_option('codecolorer_css_style'));
+        $styles = trim(wp_strip_all_tags(get_option('codecolorer_css_style')));
         if (!empty($styles)) {
             echo "<style type=\"text/css\">$styles</style>\n";
         }

--- a/codecolorer.php
+++ b/codecolorer.php
@@ -3,7 +3,7 @@
  * Plugin Name: CodeColorer
  * Plugin URI: https://kpumuk.info/projects/wordpress-plugins/codecolorer/
  * Description: This plugin allows you to insert code snippets to your posts with nice syntax highlighting powered by <a href="http://qbnz.com/highlighter/">GeSHi</a> library. After enabling this plugin visit <a href="options-general.php?page=codecolorer.php">the options page</a> to configure code style.
- * Version: 0.10.0
+ * Version: 0.10.1
  * Author: Dmytro Shteflyuk
  * Author URI: https://kpumuk.info/
  * Text Domain: codecolorer
@@ -33,7 +33,7 @@ if (version_compare(phpversion(), '7.3.0', '<')) {
     return;
 }
 
-define('CODECOLORER_VERSION', '0.10.0');
+define('CODECOLORER_VERSION', '0.10.1');
 
 /**
  * Loader class for the CodeColorer plugin

--- a/js/tinymce_plugin.js
+++ b/js/tinymce_plugin.js
@@ -47,7 +47,7 @@
         author: "Dmytro Shtefluk",
         authorurl: "https://kpumuk.info/",
         infourl: "https://kpumuk.info/projects/wordpress-plugins/codecolorer/",
-        version: "0.10.0",
+        version: "0.10.1",
       };
     },
   });

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: kpumuk
 Tags: code, snippet, syntax, highlight, highlighting, color, geshi
 Requires at least: 4.0
-Tested up to: 6.2
-Stable tag: 0.10.0
+Tested up to: 6.2.2
+Stable tag: 0.10.1
 
 CodeColorer is a syntax highlighting plugin which allows inserting code snippets into blog posts. The plugin supports color themes, code samples in RSS, comments.
 
@@ -171,6 +171,9 @@ Yes. We do not store or process any user information.
 4. Settings page.
 
 == Changelog ==
+
+= 0.10.1 (May 28, 2023) =
+* Addressed a script injection in custom CSS classes and custom CSS block.
 
 = 0.10.0 (April 28, 2023) =
 * Addressed compatibility issues with PHP 8.0+ and tested with the latest WordPress version.

--- a/tests/test_helper.php
+++ b/tests/test_helper.php
@@ -18,5 +18,10 @@ function add_filter($name, $func, $priority = 0, $arity = 0) { array_push($GLOBA
 function get_option($name) { return $GLOBALS['wp_options'][$name]; }
 function plugin_basename($file) { return 'codecolorer'; }
 function is_feed() { return $GLOBALS['wp_is_feed']; }
+function wp_strip_all_tags($text) {
+    $text = preg_replace('@<(script|style)[^>]*?>.*?</\\1>@si', '', $text);
+	$text = strip_tags($text);
+    return $text;
+}
 
 require_once 'codecolorer.php';


### PR DESCRIPTION
Admin can set custom CSS classes to include a payload like `"><script>alert(1)</script>`, triggering an XSS.