### PR TITLE
Add pedantic zizmor checks and fix GitHub Actions findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: monday
       time: "09:00"
       timezone: America/Toronto
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - javascript
@@ -17,6 +19,8 @@ updates:
       day: monday
       time: "09:00"
       timezone: America/Toronto
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,31 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  zizmor:
+    name: GitHub Actions Security
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true
+          persona: pedantic
+
   phpunit:
     runs-on: ubuntu-latest
     strategy:
@@ -41,10 +65,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none
@@ -73,7 +99,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:10.11
+        image: mariadb:10.11@sha256:407fccb51e710f34752c1a3ef9b936d1f55f38d4ac7fa043b3759742d266fd9a
         env:
           MARIADB_ROOT_PASSWORD: root
         ports:
@@ -86,10 +112,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: "8.2"
           coverage: none
@@ -103,9 +131,11 @@ jobs:
 
       - name: Install WordPress test suite
         env:
+          MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
+          WORDPRESS_VERSION: ${{ matrix.wordpress }}
           WP_INSTALL_TESTS_SKIP_UPDATE_CHECK: "true"
         run: |
-          bin/install-wp-tests.sh codecolorer_test root root 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wordpress }}
+          bin/install-wp-tests.sh codecolorer_test root root "127.0.0.1:${MYSQL_PORT}" "${WORDPRESS_VERSION}"
 
       - name: Run WordPress integration tests
         run: vendor/bin/phpunit --configuration tests/phpunit-wp.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,15 @@ concurrency:
 
 jobs:
   preflight:
+    name: Preflight Release
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install release dependencies
         run: sudo apt-get update && sudo apt-get install -y rsync subversion
@@ -49,6 +51,7 @@ jobs:
         run: DRY_RUN=1 bin/release-wordpress-org.sh "${RELEASE_TAG}"
 
   deploy:
+    name: Deploy Release
     runs-on: ubuntu-latest
     needs: preflight
     if: github.event_name == 'push' || github.event.inputs.perform_deploy == 'true'
@@ -56,9 +59,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install release dependencies
         run: sudo apt-get update && sudo apt-get install -y rsync subversion

--- a/.github/workflows/sync-assets.yml
+++ b/.github/workflows/sync-assets.yml
@@ -17,15 +17,17 @@ concurrency:
 
 jobs:
   deploy:
+    name: Sync Assets
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     environment: wordpress-org
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install release dependencies
         run: sudo apt-get update && sudo apt-get install -y rsync subversion


### PR DESCRIPTION
## Summary
- Add a dedicated `zizmor` job to CI and run it in pedantic mode.
- Fix the current GitHub Actions security findings by pinning action refs, disabling checkout credential persistence, adding explicit workflow permissions, and tightening workflow concurrency.
- Add Dependabot cooldowns and pin the MariaDB service image digest.
- Clean up workflow job naming and move GitHub Actions template values out of shell interpolation.

## Testing
- `zizmor --persona=pedantic .` passes with no findings.
- `actionlint` passes on the updated workflow files.
- `git diff --check` passes.