### PR TITLE
Prepare 0.12.0 with WordPress 7.1 coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
           - "6.8"
           - "6.9"
           - "7.0"
+          - "7.1-RC2"
 
     name: WordPress ${{ matrix.wordpress }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Mature WordPress plugin. GeSHi syntax highlighter. Supports posts, inline code, 
 - Direct unit: `vendor/bin/phpunit --configuration tests/phpunit9.xml`
 - Direct WP: `vendor/bin/phpunit --configuration tests/phpunit-wp.xml`
 - Old PHP check: GH Actions matrix tests every minor `7.0` to `8.5`
-- WP CI check: GitHub Actions tests WordPress `6.7`, `6.8`, `6.9`, `7.0` on real WP core
+- WP CI check: GitHub Actions tests WordPress `6.7`, `6.8`, `6.9`, `7.0`, `7.1-RC2` on real WP core
 - Local old PHP smoke: Docker `php:7.0-cli` + PHPUnit 6.5.14
 
 ## Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,6 @@ Mature WordPress plugin. GeSHi syntax highlighter. Supports posts, inline code, 
 - Package manager is `pnpm`, not `npm`
 - CI is GitHub Actions, not CircleCI
 - `.distignore` excludes dev files from plugin zip
-- Releases are tag-driven: plain tags like `0.11.0`
+- Releases are tag-driven: plain tags like `0.12.0`
 - WordPress.org SVN is a deploy target, not the source of truth
 - Release version touchpoints: `codecolorer.php` plugin header + `CODECOLORER_VERSION`, `readme.txt` stable tag + changelog, `README.md` release example, `js/tinymce_plugin.js` metadata, `bin/release-wordpress-org.sh` tag example/error text

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The `wp-env` setup provides a local WordPress instance for plugin development an
 
 ## Releases
 
-WordPress.org releases are tag-driven. Create a plain Git tag such as `0.11.0`; do not use a `v` prefix.
+WordPress.org releases are tag-driven. Create a plain Git tag such as `0.12.0`; do not use a `v` prefix.
 
 The GitHub release workflow builds from the tag, applies [`.distignore`](.distignore),
 publishes the plugin to WordPress.org SVN `trunk/`, and creates the matching SVN

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ mise install
 composer install
 pnpm install
 mise run test
-bin/install-wp-tests.sh codecolorer_test root root localhost 7.0
+bin/install-wp-tests.sh codecolorer_test root root localhost 7.1-RC2
 mise run test-wp
 pnpm run wp-env:start
 ```

--- a/bin/release-wordpress-org.sh
+++ b/bin/release-wordpress-org.sh
@@ -80,7 +80,7 @@ TAG="${1:-${TAG:-}}"
     exit 1
 }
 
-[[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "Tag must look like 0.11.0"
+[[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "Tag must look like 0.12.0"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SVN_URL="${SVN_URL:-https://plugins.svn.wordpress.org/codecolorer}"

--- a/codecolorer.php
+++ b/codecolorer.php
@@ -3,7 +3,7 @@
  * Plugin Name: CodeColorer
  * Plugin URI: https://kpumuk.info/projects/wordpress-plugins/codecolorer/
  * Description: This plugin allows you to insert code snippets to your posts with nice syntax highlighting powered by <a href="http://qbnz.com/highlighter/">GeSHi</a> library. After enabling this plugin visit <a href="options-general.php?page=codecolorer.php">the options page</a> to configure code style.
- * Version: 0.11.0
+ * Version: 0.12.0
  * Author: Dmytro Shteflyuk
  * Author URI: https://kpumuk.info/
  * Text Domain: codecolorer
@@ -40,7 +40,7 @@ if (version_compare(phpversion(), '7.0.0', '<')) {
     return;
 }
 
-define('CODECOLORER_VERSION', '0.11.0');
+define('CODECOLORER_VERSION', '0.12.0');
 
 /**
  * Loader class for the CodeColorer plugin

--- a/js/tinymce_plugin.js
+++ b/js/tinymce_plugin.js
@@ -47,7 +47,7 @@
         author: "Dmytro Shteflyuk",
         authorurl: "https://kpumuk.info/",
         infourl: "https://kpumuk.info/projects/wordpress-plugins/codecolorer/",
-        version: "0.11.0",
+        version: "0.12.0",
       };
     },
   });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kpumuk
 Tags: code, snippet, syntax, highlighting, comments
 Requires at least: 4.0
 Requires PHP: 7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 0.11.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: code, snippet, syntax, highlighting, comments
 Requires at least: 4.0
 Requires PHP: 7.0
 Tested up to: 7.1
-Stable tag: 0.11.0
+Stable tag: 0.12.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -176,6 +176,11 @@ Yes. We do not store or process any user information.
 4. Settings page.
 
 == Changelog ==
+
+= 0.12.0 (August 14, 2026) =
+* Added a WordPress Playground demo with sample highlighted content.
+* Added dedicated publishing for WordPress.org plugin-directory assets.
+* Expanded real WordPress compatibility coverage through WordPress 7.1 and refreshed development tooling.
 
 = 0.11.0 (March 13, 2026) =
 * Fixed comment protection for suffixed shortcodes such as `[cc_php]` and `[cci_php]`.


### PR DESCRIPTION
### Why?

WordPress 7.1 is approaching release, so compatibility regressions need to be caught before it ships and the next CodeColorer release needs matching metadata.

### How?

Add the current WordPress 7.1 release candidate to the real-core CI matrix, then prepare the 0.12.0 version metadata and changelog using the established release pattern.